### PR TITLE
Update requirements

### DIFF
--- a/VideoDownload.py
+++ b/VideoDownload.py
@@ -23,6 +23,7 @@ if os.path.exists(songsFolder):
 	videoTitle=''
 	i=0
 	erroredSongs = []
+	erroredSongNames = []
 
 	for filename in glob.iglob(homeFolder + "/**/song.ini", recursive=True):
 		i+=1
@@ -39,7 +40,7 @@ if os.path.exists(songsFolder):
 					time.sleep (0.0001)
 					pbar.update(1)
 
-					if not os.path.exists("video.mp4"):
+					if not os.path.exists("video.mp4") and not currentSongName in erroredSongNames:
 						query = '{} (Official Music Video)'.format(currentSongName)
 						print('\nLooking on YouTube for: ' + query)
 
@@ -85,8 +86,9 @@ if os.path.exists(songsFolder):
 						clean_cookie()
 			except Exception as e:
 				print(e)
-				print("Error downloading song: " + videoTitle + ". Skipping")
+				print("Error downloading song: " + currentSongName + ". Skipping")
 				erroredSongs.append(videoTitle)
+				erroredSongNames.append(currentSongName)
 				continue
 			else:
 				break

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 google>=3.0.0
-tqdm>=4.64.0
-yt-dlp>=2022.5.18
+tqdm>=4.66.1
+yt-dlp>=2023.9.24
+youtube-search-python>=1.6.6


### PR DESCRIPTION
The specified yt-dlp version (or whichever the build ships with) is not able to download videos from youtube anymore (401 errors - probably some api change). Simply works again with the newest version. Also youtube-search-python was missing in the requirements.txt.